### PR TITLE
environment.yml lacks dependency about tables

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -100,3 +100,5 @@ dependencies:
   - xz=5.2.5=h7b6447c_0
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.4.9=haebb681_0
+  - pip:
+    - tables==3.6.1


### PR DESCRIPTION
```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.3 LTS"

$ conda env create -f environment.yml
$ conda activate cotr_env
$ python demo_single_pair.py --load_weights="default"
Traceback (most recent call last):
  File "demo_single_pair.py", line 18, in <module>
    from COTR.inference.inference_helper import triangulate_corr
  File "/home/ubuntu/Apps/COTR/COTR/inference/inference_helper.py", line 12, in <module>
    from COTR.cameras.capture import crop_center_max_np, pad_to_square_np
  File "/home/ubuntu/Apps/COTR/COTR/cameras/capture.py", line 17, in <module>
    import tables
ModuleNotFoundError: No module named 'tables'
```
So I fixed `environment.yml' and it did work.
```
$ python demo_single_pair.py --load_weights="default"
cannot use vispy, setting triangulate_corr as None
---------------------- OPTIONS ----------------------

                 backbone  resnet50
                  command  demo_single_pair.py --load_weights=default
               dec_layers  6
                 dilation  False
          dim_feedforward  1024
                  dropout  0.1
               enc_layers  6
               hidden_dim  256
                    layer  layer3
             load_weights  default
        load_weights_path  ./out/default/checkpoint.pth.tar
                max_corrs  100
                   nheads  8
                  out_dir  ./out
       position_embedding  lin_sine

----------------------------------------------------
```
